### PR TITLE
Specify version of Test::More as a minimum

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,7 +47,7 @@ WriteMakefile(
     prereqs => {
       test => {
         requires => {
-          'Test::More' => 0.81_01,
+          'Test::More' => 0.82,
           'Carp' => 0,
           'Config' => 0,
           'Cwd' => 0,


### PR DESCRIPTION
We had an issue with one of our build jobs today whereby Module::metadata was failing its tests.  The problem turned out to be using note in one of the test files which was not included until Test::More 0.81_01, the first release version of this was 0.82.

This change simply adds a minimum version number for Test::More which should solve this issue.

Taken from the Test::More Changes file:
http://cpansearch.perl.org/src/EXODIST/Test-Simple-1.001003/Changes

0.81_01  Sat Sep  6 15:13:50 PDT 2008
- Added note() and explain() to both Test::More and Test::Builder.
  [rt.cpan.org 14764] [test-more.googlecode.com 3]
