### PR TITLE
Explicitly require EU::MM 6.64

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,6 @@
 use strict;
 use warnings FATAL => 'all';
-use ExtUtils::MakeMaker;
+use ExtUtils::MakeMaker 6.64;
 use 5.006;
 
 # TODO: convert to dzil and use [OnlyCorePrereqs], and possibly [DualLife]
@@ -41,7 +41,7 @@ my %META = (
     prereqs => {
       configure => {
         requires => {
-          'ExtUtils::MakeMaker' => '0',
+          'ExtUtils::MakeMaker' => '6.64',
         },
       },
       runtime => {


### PR DESCRIPTION
TEST_REQUIRES makes its debug in EU::MM 6.64, and without it,
the proper version of Test::More may not be installed and the tests will
fail (ex. on perl 5.8.9)  For example:

```
 perlbrew install --as 5.8 5.8.9
 perlbrew use 5.8
 cpanm Module::Metadata # this fails
```
