### PR TITLE
Guard against accidental failures if Log::Contextual is loaded.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,4 @@
 # https://www.kernel.org/pub/software/scm/git/docs/git-shortlog.html
 Tomas Doran <bobtfish@bobtfish.net> <tdoran@yelp.com>
 Matt S Trout <mst@shadowcat.co.uk> Matt S Trout <matthewt@hercule.scsys.co.uk>
+Kent Fredric <kentnl@cpan.org> <kentfredric@gmail.com>

--- a/lib/Module/Metadata.pm
+++ b/lib/Module/Metadata.pm
@@ -26,7 +26,10 @@ BEGIN {
 use version 0.87;
 BEGIN {
   if ($INC{'Log/Contextual.pm'}) {
-    Log::Contextual->import('log_info');
+    require "Log/Contextual/WarnLogger.pm"; # Hide from AutoPrereqs
+    Log::Contextual->import('log_info',
+      '-default_logger' => Log::Contextual::WarnLogger->new({ env_prefix => 'MODULE_METADATA', }),
+    );
   } else {
     *log_info = sub (&) { warn $_[0]->() };
   }

--- a/xt/author/compat_lc.t
+++ b/xt/author/compat_lc.t
@@ -1,0 +1,31 @@
+
+use strict;
+use warnings;
+
+use Test::More;
+
+# ABSTRACT: Make sure not to fail if Log::Contextual is accidentally uninitialised
+
+BEGIN {
+    eval { require "Log/Contextual.pm"; 1 }
+      or plan skip_all => "Log::Contexual required installed for this test";
+}
+
+use Module::Metadata;
+
+my ( $ok, $error ) = do {
+    local $@;
+    my $rval = eval {
+        package Module::Metadata; # Required because "default" applies to caller context
+        # So this test is mimicing internal calls
+        Module::Metadata::log_info { "something" };
+        1;
+    };
+    ( $rval, $@ );
+};
+
+ok( $ok, "Log::Contextual being loaded didn't cause an explosion" )
+  or note $error;
+
+done_testing;
+


### PR DESCRIPTION
If by chance Module::Metadata happened to be loaded in a system where
Log::Contextual was loaded, but not configured, Module::Metadata calling
the relevant logging methods caused a fatal exception.

This change permits Module::Metadata to construct its own logger if
it plans on using Log::Contexual, such that if one is not configured,
the default will still work.

Additionally, the default logger can be adjusted in the user ENV by
tweaking MODULE_METADATA_<> fields when Log::Contexual is loaded.

Its unlikely a user will stumble into this edge case, as it only happens
in error conditions, and then, only in a rarely used codepath in
Module::Metadata.

Namely:
```
  log_info -
    <- $compare_versions
      <- $resolve_module_versions
        <- package_versions_from_directory(&1)
      <- package_versions_from_directory(&1)
    <- package_versions_from_directory=&1
      <- provides
```
Of these methods, only package_versions_from_directory has a single
test, and that single test doesn't trip the error conditions.