### PR TITLE
skip taint.t if no taint support

### DIFF
--- a/t/taint.t
+++ b/t/taint.t
@@ -2,7 +2,9 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2;
+use Config;
+use Test::More $Config{ccflags} =~ /-DSILENT_NO_TAINT_SUPPORT/
+    ? ( skip_all => 'No taint support' ) : ( tests => 2 );
 use Module::Metadata;
 use Carp 'croak';
 


### PR DESCRIPTION
t/taint.t assumes that perl -T will turn on tainting, tainting is an optional feature of Perl, so it should be tested for.

The attached patch skips all the tests in this file if Config says that the Perl was compiled with no taint support.