### PR TITLE
Also look in Module::Metadata's own namespace for the version variable.

### DIFF
--- a/lib/Module/Metadata.pm
+++ b/lib/Module/Metadata.pm
@@ -652,7 +652,8 @@ sub _evaluate_version_line {
     sub {
       local $sigil$variable_name;
       $line;
-      \$$variable_name
+      return \$$variable_name if defined \$$variable_name;
+      return \$Module::Metadata::_version::p${pn}::$variable_name;
     };
   };
 


### PR DESCRIPTION
This resolves a failure observed on 5.6.2.

http://www.cpantesters.org/cpan/report/7dbe76b8-a71b-11e4-8aed-a1a4227a829d