### PR TITLE
fix package_version_from_directory breakage with absolute file on win32

### DIFF
--- a/lib/Module/Metadata.pm
+++ b/lib/Module/Metadata.pm
@@ -260,7 +260,7 @@ sub new_from_module {
     # separating into primary & alternative candidates
     my( %prime, %alt );
     foreach my $file (@files) {
-      my $mapped_filename = File::Spec::Unix->abs2rel( $file, $dir );
+      my $mapped_filename = File::Spec->abs2rel( $file, $dir );
       my @path = split( /\//, $mapped_filename );
       (my $prime_package = join( '::', @path )) =~ s/\.pm$//;
 

--- a/lib/Module/Metadata.pm
+++ b/lib/Module/Metadata.pm
@@ -261,7 +261,7 @@ sub new_from_module {
     my( %prime, %alt );
     foreach my $file (@files) {
       my $mapped_filename = File::Spec->abs2rel( $file, $dir );
-      my @path = split( /\//, $mapped_filename );
+      my @path = File::Spec->splitdir( $mapped_filename );
       (my $prime_package = join( '::', @path )) =~ s/\.pm$//;
 
       my $pm_info = $class->new_from_file( $file );

--- a/t/metadata.t
+++ b/t/metadata.t
@@ -16,7 +16,7 @@ use GeneratePackage;
 
 my $tmpdir = GeneratePackage::tmpdir();
 
-plan tests => 70;
+plan tests => 71;
 
 require_ok('Module::Metadata');
 
@@ -432,9 +432,16 @@ Simple Simon
     }
   };
 
-  my $got_pvfd = Module::Metadata->package_versions_from_directory('lib');
+  my $dir = "lib";
+  my $got_pvfd = Module::Metadata->package_versions_from_directory($dir);
 
   is_deeply( $got_pvfd, $exp_pvfd, "package_version_from_directory()" )
+    or diag explain $got_pvfd;
+
+  my $absolute_file = File::Spec->rel2abs($exp_pvfd->{Simple}{file}, $dir);
+  my $got_pvfd2 = Module::Metadata->package_versions_from_directory($dir, [$absolute_file]);
+
+  is_deeply( $got_pvfd2, $exp_pvfd, "package_version_from_directory() with provided absolute file path" )
     or diag explain $got_pvfd;
 
 {


### PR DESCRIPTION
As discussed on IRC this PR contains a fix with test for absolute file paths being given to package_version_from_directory.

It also contains a related fix, which still needs test as per #23.
