### PR TITLE
Add $self->{inc} to @INC whilst evaluating version

### DIFF
--- a/lib/Module/Metadata.pm
+++ b/lib/Module/Metadata.pm
@@ -693,6 +693,10 @@ sub _evaluate_version_line {
   $eval = $1 if $eval =~ m{^(.+)}s;
 
   local $^W;
+
+  # if inc has been set, look there for any required modules
+  local @INC = (@{$self->{inc}}, @INC) if defined $self->{inc};
+
   # Try to get the $VERSION
   my $vsub = __clean_eval($eval);
   # some modules say $VERSION <equal sign> $Foo::Bar::VERSION, but Foo::Bar isn't

--- a/t/lib/0_1/Bar.pm
+++ b/t/lib/0_1/Bar.pm
@@ -1,0 +1,12 @@
+package Bar;
+our $VERSION = '0.1';
+
+package Bar::History;
+
+# adapted from WWW::Scripter
+<<'mldistwatch' if 0;
+use Bar; $VERSION = $Bar'VERSION;
+mldistwatch
+our $VERSION = $Bar'VERSION;
+
+1;

--- a/t/version.t
+++ b/t/version.t
@@ -4,7 +4,7 @@ use Test::More;
 use Module::Metadata;
 use lib "t/lib/0_2";
 
-plan tests => 4;
+plan tests => 6;
 
 require Foo;
 is($Foo::VERSION, 0.2, 'affirmed version of loaded module');
@@ -17,8 +17,6 @@ is($Foo::VERSION, 0.2, 'loaded module still retains its version');
 ok(eval "use Foo 0.2; 1", 'successfully loaded module again')
     or diag 'got exception: ', $@;
 
-
-
-
-
-
+my $bar_meta = Module::Metadata->new_from_module("Bar", inc => [ "t/lib/0_1" ] );
+is scalar @{$bar_meta->{packages}}, 2, 'found 2 packages in Bar';
+is $bar_meta->{versions}{'Bar::History'}, $bar_meta->{versions}{'Bar'}, 'Bars version gets passed to Bar::History';


### PR DESCRIPTION
WWW::Scripter defines multiple packages in the same file, some of those
packages contain a block of text that Module::Metadata tries to evaluate
to get a version. I've added t/lib/0_1/Bar.pm which contains the whole offending block but essentially the line that Module::Metadata tries to evaluate is
"use WWW::Scripter; use WWW::Scripter; $VERSION = $WWW'Scripter'VERSION;"

When using Carton to install WWW::Scripter this causes Module::Metadata
to error with "Can't find module". This is due all the modules being installed in a local/lib directory. If we add $self->{inc} to @INC before evaluating the version line then Perl looks in the right places for the WWW::Scripter module.