### PR TITLE
Parse `class` syntax of `Object::Pad` (closes #33)

### DIFF
--- a/lib/Module/Metadata.pm
+++ b/lib/Module/Metadata.pm
@@ -554,6 +554,7 @@ sub _parse_fh {
   my $pod_data = '';
   my $in_end = 0;
   my $encoding = '';
+  my $seen_Object_Pad = 0;
 
   while (defined( my $line = <$fh> )) {
     my $line_num = $.;
@@ -633,8 +634,7 @@ sub _parse_fh {
       }
     }
 
-    # TODO: Only armed if we've seen a `use Object::Pad`
-    elsif ( $line =~ /$CLASS_REGEXP/o ) {
+    elsif ( $seen_Object_Pad and $line =~ /$CLASS_REGEXP/o ) {
       $package = $1;
       my $version = $2;
       push( @packages, $package ) unless grep( $package eq $_, @packages );
@@ -681,6 +681,10 @@ sub _parse_fh {
       unless ( defined $vers{$package} && length $vers{$package} ) {
         $vers{$package} = $v;
       }
+    }
+
+    if( $line =~ /^\s*use\s+Object::Pad\b[^:]/ ) {
+      $seen_Object_Pad = 1;
     }
   } # end loop over each line
 

--- a/lib/Module/Metadata.pm
+++ b/lib/Module/Metadata.pm
@@ -86,8 +86,6 @@ my $CLASS_REGEXP = qr{  # match a class declaration from Object::Pad
   ($PKG_NAME_REGEXP)    # a package name
   \s*                   # optional whitespace
   ($V_NUM_REGEXP)?      # optional version number
-  \s*                   # optional whitespace
-  [;\{]                 # semicolon line terminator or block start
 }x;
 
 my $VARNAME_REGEXP = qr{ # match fully-qualified VERSION name

--- a/t/extract-package.t
+++ b/t/extract-package.t
@@ -135,6 +135,14 @@ use Object::Pad;
 class Simple::Edward;
 ---
 },
+{
+  name => 'class NAME::SUBNAME extends NAME',
+  package => [ 'main', 'Simple::Edward' ],
+  code => <<'---',
+use Object::Pad;
+class Simple::Edward extends Another::Package;
+---
+},
 );
 
 my $test_num = 0;

--- a/t/extract-package.t
+++ b/t/extract-package.t
@@ -127,6 +127,13 @@ $VERSION = '999';
 $::VERSION = 0.01;
 ---
 },
+{
+  name => 'class NAME::SUBNAME',
+  package => [ 'Simple::Edward' ],
+  code => <<'---',
+class Simple::Edward;
+---
+},
 );
 
 my $test_num = 0;

--- a/t/extract-package.t
+++ b/t/extract-package.t
@@ -129,8 +129,9 @@ $::VERSION = 0.01;
 },
 {
   name => 'class NAME::SUBNAME',
-  package => [ 'Simple::Edward' ],
+  package => [ 'main', 'Simple::Edward' ],
   code => <<'---',
+use Object::Pad;
 class Simple::Edward;
 ---
 },

--- a/t/extract-version.t
+++ b/t/extract-version.t
@@ -614,36 +614,40 @@ our $VERSION = '1.23';
 {
   name => 'class statement decimal',
   code => <<'---',
+use Object::Pad;
 class Simple 1.23;
 ---
   vers => '1.23',
-  all_versions => { 'Simple' => '1.23' },
+  all_versions => { 'Simple' => '1.23', main => '' },
 },
 {
   name => 'class statement v-string',
   code => <<'---',
+use Object::Pad;
 class Simple v1.24;
 ---
   vers => 'v1.24',
-  all_versions => { 'Simple' => 'v1.24' },
+  all_versions => { 'Simple' => 'v1.24', main => '' },
 },
 {
   name => 'class block decimal',
   code => <<'---',
+use Object::Pad;
 class Simple 1.25 {
 }
 ---
   vers => '1.25',
-  all_versions => { 'Simple' => '1.25' },
+  all_versions => { 'Simple' => '1.25', main => '' },
 },
 {
   name => 'class block v-string',
   code => <<'---',
+use Object::Pad;
 class Simple v1.26 {
 }
 ---
   vers => 'v1.26',
-  all_versions => { 'Simple' => 'v1.26' },
+  all_versions => { 'Simple' => 'v1.26', main => '' },
 },
 );
 

--- a/t/extract-version.t
+++ b/t/extract-version.t
@@ -611,6 +611,40 @@ our $VERSION = '1.23';
   vers => $undef,
   all_versions => { 'ThisIsNotSimple' => '1.23' },
 },
+{
+  name => 'class statement decimal',
+  code => <<'---',
+class Simple 1.23;
+---
+  vers => '1.23',
+  all_versions => { 'Simple' => '1.23' },
+},
+{
+  name => 'class statement v-string',
+  code => <<'---',
+class Simple v1.24;
+---
+  vers => 'v1.24',
+  all_versions => { 'Simple' => 'v1.24' },
+},
+{
+  name => 'class block decimal',
+  code => <<'---',
+class Simple 1.25 {
+}
+---
+  vers => '1.25',
+  all_versions => { 'Simple' => '1.25' },
+},
+{
+  name => 'class block v-string',
+  code => <<'---',
+class Simple v1.26 {
+}
+---
+  vers => 'v1.26',
+  all_versions => { 'Simple' => 'v1.26' },
+},
 );
 
 my $test_num = 0;


### PR DESCRIPTION
Currently the extra syntax is guarded by requiring a line looking like

    use Object::Pad

in order not to get confused by any other syntax as possibly provided by other modules. The eventual goal of `Object::Pad` and `Cor` is that hopefully one day this will become core syntax, at which point such guarding can be removed.